### PR TITLE
Noun list suggested sanitisation.

### DIFF
--- a/lib/haikunator.rb
+++ b/lib/haikunator.rb
@@ -294,6 +294,7 @@ module Haikunator
         accolade
         achievement
         adventure
+        alliance
         aptitude
         ascension
         awakening
@@ -536,7 +537,6 @@ module Haikunator
         sunset
         supernova
         support
-        supremacy
         surf
         sweetness
         symphony


### PR DESCRIPTION
Replaced `supremacy` with `alliance`. This avoids unsavoury incident names